### PR TITLE
Feature sparse sets and pools

### DIFF
--- a/source/ecs/component.d
+++ b/source/ecs/component.d
@@ -1,0 +1,77 @@
+module ecs.component;
+
+import std.exception : basicExceptionCtors;
+
+version(unittest) import aurorafw.unit.assertion;
+
+
+/**
+ * Type which defines a valid component.
+ * Use it as an **UDA** in a struct to define it as a component.
+ *
+ * Examples:
+ * --------------------
+ * @Component struct ValidComponent {}
+ * --------------------
+ */
+public enum Component;
+
+
+/**
+ * Verifies a valid Component. C is a component if it's a **struct** and has the
+ *     **Component UDA** attached.
+ *
+ * Examples:
+ * --------------------
+ * @Component struct ValidComponent {}
+ * struct InvalidComponent {}
+ *
+ * assert(isComponent!ValidComponent);
+ * assert(!isComponent!InvalidComponent);
+ * --------------------
+ *
+ * Params:
+ *     C = struct to validate.
+ *
+ * Returns: `true` if it's a component, `false` otherwise.
+ */
+public template isComponent(C)
+	if(is(C == struct))
+{
+	import std.traits : hasUDA;
+	enum isComponent = hasUDA!(C, Component);
+}
+
+
+@safe pure
+@("component: isComponent")
+unittest
+{
+	@Component struct ComponentValid {}
+
+	struct ComponentInvalid {}
+	@Component class ClassInvalid {}
+	@Component int variableInvalid;
+
+	assertTrue(isComponent!ComponentValid);
+	assertFalse(isComponent!ComponentInvalid);
+	assertFalse(__traits(compiles, isComponent!ClassInvalid));
+	assertFalse(__traits(compiles, isComponent!variableInvalid));
+}
+
+
+/**
+ * Returns the unique hash of the component. \
+ * This is used internaly in the Registry to forge Pool ids.
+ *
+ * Params:
+ *     C = a valid component
+ *
+ * Returns:
+ *     An unique hash of C
+ */
+package template componentId(C)
+	if (isComponent!C)
+{
+	enum componentId = typeid(C).name.hashOf();
+}

--- a/source/ecs/entity.d
+++ b/source/ecs/entity.d
@@ -1,0 +1,195 @@
+module ecs.entity;
+
+import std.exception : basicExceptionCtors;
+
+version(unittest) import aurorafw.unit.assertion;
+
+
+/**
+ * Trait which checks if a type is a valid entity type. An entity type must be
+ *     unsigned and integral. These are all the accepted types: ***ubyte, ushort,
+ *     uint, ulong***.
+ *
+ * Params: T = a type to be validated.
+ *
+ * Returns: `true` if is a valid type, `false` otherwise
+ */
+public template isEntityType(T)
+{
+	import std.traits : isUnsigned, isIntegral;
+	enum isEntityType = isUnsigned!T && isIntegral!T;
+}
+
+
+@safe pure
+@("entity: isEntityType")
+unittest
+{
+	import std.meta : AliasSeq;
+	static foreach(t; AliasSeq!(ubyte, ushort, uint, ulong))
+	{
+		assertTrue(isEntityType!t);
+	}
+
+	struct Foo {}
+	static foreach(t; AliasSeq!(byte, short, int, long, char, dchar, string, dstring, float, double, Foo))
+	{
+		assertFalse(isEntityType!t);
+	}
+}
+
+
+/**
+ * Trait which checks if a bit id amount is valid for a certaint entity type.
+ *
+ * Params:
+ *     T = entity type used for validation.
+ *     idBitAmount = bit amount to validate.
+ *
+ * Returns: `true` if amount is between 1 and T.sizeof * 8, `false` otherwise.
+ *
+ * See_Also: $(LREF isEntityType)
+ */
+package template isValidBitIdAmount(T, T idBitAmount)
+	if (isEntityType!T)
+{
+	enum isValidBitIdAmount = idBitAmount < T.sizeof * 8 && idBitAmount > T.min;
+}
+
+
+@safe pure
+@("entity: isValidBitIdAMount")
+unittest
+{
+	import std.meta : AliasSeq;
+	static foreach(t; AliasSeq!(ubyte, ushort, uint, ulong))
+	{
+		assertTrue(isValidBitIdAmount!(t, 1));
+		assertTrue(isValidBitIdAmount!(t, t.sizeof * 8 - 1));
+
+		assertFalse(isValidBitIdAmount!(t, t.min));
+		assertFalse(isValidBitIdAmount!(t, t.sizeof * 8));
+	}
+
+	struct Foo {}
+	static foreach(t; AliasSeq!(byte, short, int, long, char, dchar, string, dstring, float, double, Foo))
+	{
+		assertFalse(__traits(compiles, isValidBitIdAmount!(t, 1)));
+	}
+}
+
+
+/**
+ * Generate needed masks and shift values. \
+ * These values are defined by the variable type and the amount of id bits you
+ *     use. \
+ * You can only generate masks and shift values of unsigned and integral types,
+ *     ***ubyte, ushort, uint, ulong***. \
+ * The amount is of type T meaning you cannot pass any value lower than 0 or
+ *     higher than T.max; to complement these default type constraints you cannot
+ *     pass a value equal to 0 as this would mean no space for ids or equal to
+ *     T.sizeof * 8 as this would mean no space for batches. \
+ * \
+ * There are some default alises available for fast access.
+ *
+ * | alias-name | id-(bits) | batch-(bits) | max-entities  | batch-reset   |
+ * | :--------- | :-------: | :----------: | :-----------: | :-----------: |
+ * | Registry   | 20        | 12           | 1_048_574     | 4_096         |
+ * | Registry8  | 4         | 4            | 14            | 16            |
+ * | Registry16 | 8         | 8            | 254           | 256           |
+ * | Registry32 | 16        | 16           | 65_534        | 65_536        |
+ * | Registry64 | 32        | 32           | 4_294_967_295 | 4_294_967_296 |
+ *
+ * Registry:
+ * + id: ***20 bits*** (max at `1_048_574`)
+ * + batch: ***12 bits*** (resets at `4_096`)
+ *
+ * Registry8:
+ * + id: ***4 bits*** (max at `14`)
+ * + batch: ***4 bits*** (resets at `16`)
+ *
+ * Registry16:
+ * + id: ***8 bits*** (max at `254`)
+ * + batch: ***8 bits*** (resets at `256`)
+ *
+ * Registry32:
+ * + id: ***16 bits*** (max at `65_534`)
+ * + batch: ***16 bits*** (resets at `65_536`)
+ *
+ * Registry64:
+ * + id: ***32 bits*** (max at `4_294_967_295`)
+ * + batch: ***32 bits*** (resets at `4_294_967_296`)
+ *
+ * Params:
+ *     T = entity type.
+ *     idBitAmount = number of bits reserved for the id.
+ *
+ * Code_Generation:
+ * + `entityShift` = the shift value needed to access the batch.
+ * + `entityMask` = the mask to extract the entity id.
+ * + `batchMask` = the mask to extract the entity batch.
+ * + `entityNull` = reserved value to for representing an empty queue as well as
+ *     the maximum of entities.
+ *
+ * See_Also: $(LREF isEntityType), $(LREF isValidBitIdAmount)
+ */
+package mixin template genEntityBitMasks(T, T idBitAmount)
+	if(isEntityType!T && isValidBitIdAmount!(T, idBitAmount))
+{
+	public enum T entityShift = idBitAmount;
+	public enum T entityMask = (1UL << idBitAmount) - 1;
+	public enum T batchMask = (1UL << (T.sizeof * 8 - idBitAmount)) - 1;
+	public enum T entityNull = entityMask;
+}
+
+
+@safe pure
+@("entity: genEntityBitMasks")
+unittest
+{
+	assertFalse(__traits(compiles, genEntityBitMasks!(uint, uint.min)));
+	assertFalse(__traits(compiles, genEntityBitMasks!(uint, uint.sizeof * 8)));
+
+	mixin genEntityBitMasks!(uint, 4);
+	assertEquals(4, entityShift);
+	assertEquals(0xF, entityMask);
+	assertEquals(0xFFFF_FFF, batchMask);
+	assertEquals(0xF, entityNull);
+}
+
+
+/**
+ * Simple exception for entity errors.
+ */
+public class EntityException : Exception
+{
+	mixin basicExceptionCtors;
+}
+
+
+///
+public class InvalidEntityException : EntityException
+{
+	mixin basicExceptionCtors;
+}
+
+
+///
+public final class MaximumEntitiesReachedException : EntityException
+{
+	mixin basicExceptionCtors;
+}
+
+
+///
+public final class EntityNotInPoolException : InvalidEntityException
+{
+	mixin basicExceptionCtors;
+}
+
+
+///
+public final class EntityInPoolException : InvalidEntityException
+{
+	mixin basicExceptionCtors;
+}

--- a/source/ecs/package.d
+++ b/source/ecs/package.d
@@ -1,0 +1,8 @@
+module ecs;
+
+public:
+	import ecs.component;
+	import ecs.entity;
+	import ecs.pool;
+	import ecs.registry;
+	import ecs.sparseset;

--- a/source/ecs/pool.d
+++ b/source/ecs/pool.d
@@ -35,7 +35,7 @@ public:
 	 * See_Also: $(REF add, ecs.sparseset)
 	 */
 	@safe pure
-	void add(const inout(T) entity, const inout(C) component)
+	void add(in T entity, in C component)
 		in (!super.contains(entity))
 	{
 		packedComponents ~= component;
@@ -59,7 +59,7 @@ public:
 	 * Returns: a pointer to the respective component.
 	 */
 	@safe pure
-	C* get(const inout(T) entity)
+	C* get(in T entity)
 		in (super.contains(entity))
 	{
 		auto saferef = (() @trusted pure {
@@ -86,7 +86,7 @@ public:
 	 * See_Also: $(REF remove, ecs.sparseset)
 	 */
 	@safe pure override
-	void remove(const inout(T) entity)
+	void remove(in T entity)
 		in (super.contains(entity))
 	{
 		import std.algorithm : swap;

--- a/source/ecs/pool.d
+++ b/source/ecs/pool.d
@@ -62,6 +62,14 @@ public:
 	}
 
 
+	@safe pure @live
+	void modify(in T entity, scope ref C component)
+		in (super.contains(entity))
+	{
+		packedComponents[entities[idOf(entity)]] = component;
+	}
+
+
 	/**
 	 * Removes an entity from the pool.
 	 *

--- a/source/ecs/pool.d
+++ b/source/ecs/pool.d
@@ -1,0 +1,203 @@
+module ecs.pool;
+
+import ecs.component;
+import ecs.sparseset;
+
+version(unittest) import aurorafw.unit.assertion;
+
+
+/**
+ * Creates a component pool class of an EntityType. \
+ * This is similar to SparseSet however with an extra **packed array** with
+ *     **components**. This array is kept in sync with the **packed entities**.
+ *     Each element belongs to the entity of the **packed entities** array
+ *     contained in the same index.
+ *
+ * Params:
+ *     T = valid EntityType.
+ *     idBitAmount = a valid number of bits reserved for the id.
+ *     C = valid Component.
+ *
+ * See_Also: $(REF SparseSet, ecs.sparseset)
+ */
+@safe pure
+package final class Pool(T, T idBitAmount, C) : SparseSet!(T, idBitAmount)
+	if (isComponent!C)
+{
+public:
+	/**
+	 * Associate a component to an entity in the pool.
+	 *
+	 * Params:
+	 *     entity = valid entity to add.
+	 *     component = a valid component to add.
+	 *
+	 * See_Also: $(REF add, ecs.sparseset)
+	 */
+	@safe pure
+	void add(const inout(T) entity, const inout(C) component)
+		in (!super.contains(entity))
+	{
+		packedComponents ~= component;
+		super.add(entity);
+	}
+
+
+	/**
+	 * Get a component from an entity.
+	 *
+	 * Params: entity = valid entity to search.
+	 *
+	 * Returns: a pointer to the respective component.
+	 */
+	@safe pure
+	C* get(const inout(T) entity)
+		in (super.contains(entity))
+	{
+		auto saferef = (() @trusted pure {
+			return &packedComponents[entities[idOf(entity)]];
+		})();
+
+		return saferef;
+	}
+
+
+	/**
+	 * Removes an entity from the pool.
+	 *
+	 * Params: entity = a valid entity to remove.
+	 *
+	 * See_Also: $(REF remove, ecs.sparseset)
+	 */
+	@safe pure override
+	void remove(const inout(T) entity)
+		in (super.contains(entity))
+	{
+		import std.algorithm : swap;
+		import std.range : back, popBack;
+
+		swap(packedComponents.back, packedComponents[entities[idOf(entity)]]);
+		packedComponents.popBack();
+		super.remove(entity);
+	}
+
+
+private:
+	C[] packedComponents;
+}
+
+
+version(unittest)
+{
+	import ecs.component : Component;
+	private @Component struct Position { float x, y; }
+	private @Component struct Velocity { float dx, dy; }
+	private struct NotComponent {}
+}
+
+
+@system pure
+@("pool: add")
+unittest
+{
+	import core.exception : AssertError;
+	import std.exception : assertThrown;
+
+	Pool!(uint, 20, Position) pool = new Pool!(uint, 20, Position);
+	const uint e0 = 0; // simulates an entity with id(0) and batch(0)
+	const uint e6 = 6; // simulates an entity with id(6) and batch(0)
+	const uint e01 = (1 << 20) | 0; // simulates an entity with id(0) and batch(1)
+
+	assertFalse(__traits(compiles, pool.add(e0, Velocity(0, 0))));
+
+	assertEquals(0, pool.packedComponents.length);
+
+	pool.add(e0, Position(2, 3));
+	assertEquals(1, pool.packedComponents.length);
+
+	// in this case we can use the entity directly because we know the batch is 0
+	// but internaly only the id of the entity is used as an index
+	assertTrue(Position(2, 3) == pool.packedComponents[0]);
+
+	pool.add(e6, Position(4, 5));
+
+	assertEquals(2, pool.packedComponents.length);
+	assertTrue(Position(4, 5) == pool.packedComponents[1]);
+
+	assertThrown!AssertError(pool.add(e0, Position(9, 9)));
+
+	pool.add(e01, Position(9, 9)); // same id but diferent batch so it adds
+
+	// now it creates a problem, the new entity was placed at the end of the packedEntities
+	// however it's id is the same as e0 and e0 was not removed!
+	// if you now remove e0 from this pool this will remove e01 from packedEntities
+	// this example will not happen in the actual world because this tested in registry
+	// and at this point e0 was already discarded and removed from this pool
+	assertEquals(3, pool.packedComponents.length);
+	assertTrue(Position(9, 9) == pool.packedComponents[2]);
+}
+
+
+@system pure
+@("pool: get")
+unittest
+{
+	import core.exception : AssertError;
+	import std.exception : assertThrown;
+
+	Pool!(uint, 20, Position) pool = new Pool!(uint, 20, Position);
+	const uint e0 = 0; // simulates an entity with id(0) and batch(0)
+	const uint e6 = 6; // simulates an entity with id(6) and batch(0)
+
+	pool.add(e0, Position(2, 3));
+	assertThrown!AssertError(pool.get(e6));
+
+	Position* position = pool.get(e0);
+	assertTrue(*position == Position(2, 3));
+
+	*position = Position(3, 8);
+
+	assertTrue(*position == *pool.get(e0));
+	assertTrue(3 == pool.get(e0).x);
+	assertTrue(8 == pool.get(e0).y);
+}
+
+
+@safe pure
+@("pool: pool initialization")
+unittest
+{
+	assertTrue(__traits(compiles, new Pool!(uint, 20, Position)));
+	assertFalse(__traits(compiles, new Pool!(uint, 20, NotComponent)));
+}
+
+
+@system pure
+@("pool: remove")
+unittest
+{
+	import core.exception : AssertError;
+	import std.exception : assertThrown;
+
+	Pool!(uint, 20, Position) pool = new Pool!(uint, 20, Position);
+	const uint e0 = 0; // simulates an entity with id(0) and batch(0)
+	const uint e6 = 6; // simulates an entity with id(6) and batch(0)
+	const uint e61 = (1 << 20) | 6; // simulates an entity with id(6) and batch(1)
+
+	pool.add(e6, Position(2, 5));
+	pool.add(e0, Position(8, 8));
+
+	assertTrue(Position(2, 5) == pool.packedComponents[0]);
+	assertTrue(Position(8, 8) == pool.packedComponents[1]);
+
+	assertThrown!AssertError(pool.remove(e61));
+
+	// simulate the discard of e6
+	pool.remove(e6);
+
+	assertTrue(Position(8, 8) == pool.packedComponents[0]);
+	pool.add(e61, Position(17, 15));
+
+	assertTrue(Position(8, 8) == pool.packedComponents[0]);
+	assertTrue(Position(17, 15) == pool.packedComponents[1]);
+}

--- a/source/ecs/pool.d
+++ b/source/ecs/pool.d
@@ -43,6 +43,14 @@ public:
 	}
 
 
+	@safe pure
+	bool contains(in T entity, in C component)
+	{
+		return super.contains(entity)
+			&& packedComponents[entities[idOf(entity)]] == component;
+	}
+
+
 	/**
 	 * Get a component from an entity.
 	 *

--- a/source/ecs/registry.d
+++ b/source/ecs/registry.d
@@ -1,4 +1,4 @@
-module registry;
+module ecs.registry;
 
 import std.exception : basicExceptionCtors;
 

--- a/source/ecs/registry.d
+++ b/source/ecs/registry.d
@@ -411,38 +411,182 @@ public:
 
 
 	/**
-	 * Checks if an entity, valid or not, contains a component. \
-	 * \
-	 * If the entity isn't valid or the component pool doesn't exist or the
-	 *     entity does not contain it, it returs `false`!
+	 * Contains a component. \
 	 *
-	 * Params:
-	 *     C = valid component to check.
-	 *     entity = entity to search.
-	 *
-	 * Returns: `true` if the entity contains the component, `false` otherwise.
+	 * Params: C = valid component to check.
 	 */
-	@safe pure
-	bool contains(C)(const inout(T) entity)
+	template contains(C)
 		if (isComponent!C)
 	{
-		return isValid(entity)
+		/**
+		 * Checks if an entity, valid or not, contains a component. \
+		 * \
+		 * If the entity isn't valid or the component pool doesn't exist or the
+		 *     entity does not contain it, it returns `false`!
+		 *
+		 * Params: entity = entity to search.
+		 *
+		 * Returns: `true` if the entity contains the component, `false` otherwise.
+		 */
+		auto contains(in T entity)
+		{
+			return isValid(entity)
 				&& componentId!C in pools
 				&& pools[componentId!C].pool.contains(entity);
+		}
+
+
+		/**
+		 * Checks if an entity, valid or not, contains a component. \
+		 * \
+		 * If the entity isn't valid or the component pool doesn't exist or the
+		 *     entity does not contain it, it returns `false`!
+		 *
+		 * Params:
+		 *     component = valid component to check.
+		 *     entity = entity to search.
+		 *
+		 * Returns: `true` if the entity contains the component, `false` otherwise.
+		 */
+		auto contains(in T entity, in C component)
+		{
+			return isValid(entity)
+				&& componentId!C in pools
+				&& (cast(Pool!(T, idBitAmount, C))(pools[componentId!C].pool)).contains(entity, component);
+		}
+
+
+		/**
+		 * Checks if all entities, valid or not, contain a component. \
+		 * \
+		 * If the entity isn't valid or the component pool doesn't exist or the
+		 *     entity does not contain it, it returns `false`!
+		 *
+		 * Params: entities = entities to search.
+		 *
+		 * Returns: `true` if all entities contain the component, `false` otherwise.
+		 */
+		auto contains(in T[] entities)
+		{
+			import std.algorithm : each;
+			import std.typecons : No, Yes;
+
+			return entities.each!(e => contains!C(e) ? Yes.each : No.each) == Yes.each;
+		}
+
+
+		/**
+		 * Checks if all entities, valid or not, contain a component. \
+		 * \
+		 * If the entity isn't valid or the component pool doesn't exist or the
+		 *     entity does not contain it, it returns `false`!
+		 *
+		 * Params:
+		 *     component = valid component to check.
+		 *     entities = entities to search.
+		 *
+		 * Returns: `true` if all entities contain the component, `false` otherwise.
+		 */
+		auto contains(in T[] entities, in C component)
+		{
+			import std.algorithm : each;
+			import std.typecons : No, Yes;
+
+			return entities.each!(e => contains!C(e, component) ? Yes.each : No.each) == Yes.each;
+		}
 	}
 
 
-	///
-	@safe pure
-	bool contains(C ...)(const inout(T) entity)
-		if (allSatisfy!(isComponent, C))
+	/**
+	 * Contains components. \
+	 *
+	 * Params: RangeC = valid components to check.
+	 */
+	template contains(RangeC ...)
+		if (RangeC.length > 1)
 	{
-		foreach (component; C)
+		/**
+		 * Checks if an entity, valid or not, contains all components. \
+		 * \
+		 * If the entity isn't valid or a component pool doesn't exist or the
+		 *     entity does not contain it, it returns `false`!
+		 *
+		 * Params: entity = entity to search.
+		 *
+		 * Returns: `true` if all entities contain all components, `false` otherwise.
+		 */
+		auto contains(in T entity)
 		{
-			if (!contains!component(entity))
-				return false;
+			foreach (C; RangeC)
+			{
+				if (!contains!C(entity))
+					return false;
+			}
+			return true;
 		}
-		return true;
+
+
+		/**
+		 * Checks if an entity, valid or not, contains all components. \
+		 * \
+		 * If the entity isn't valid or a component pool doesn't exist or the
+		 *     entity does not contain it, it returns `false`!
+		 *
+		 * Params:
+		 *     components = valid components to check.
+		 *     entity = entity to search.
+		 *
+		 * Returns: `true` if the entity contains all components, `false` otherwise.
+		 */
+		auto contains(in T entity, RangeC components)
+		{
+			foreach (ref component; components)
+			{
+				if (!contains(entity, component))
+					return false;
+			}
+			return true;
+		}
+
+
+		/**
+		 * Checks if all entities, valid or not, contain all components. \
+		 * \
+		 * If any entity isn't valid or a component pool doesn't exist or the
+		 *     entity does not contain it, it returns `false`!
+		 *
+		 * Params: entities = entities to search.
+		 *
+		 * Returns: `true` if all entities contain all components, `false` otherwise.
+		 */
+		auto contains(in T[] entities)
+		{
+			import std.algorithm : each;
+			import std.typecons : No, Yes;
+
+			return entities.each!(e => contains!(RangeC)(e) ? Yes.each : No.each) == Yes.each;
+		}
+
+
+		/**
+		 * Checks if all entities, valid or not, contain all components. \
+		 * \
+		 * If any entity isn't valid or a component pool doesn't exist or the
+		 *     entity does not contain it, it returns `false`!
+		 *
+		 * Params:
+		 *     components = valid components to check.
+		 *     entities = entities to search.
+		 *
+		 * Returns: `true` if all entities contain all components, `false` otherwise.
+		 */
+		auto contains(in T[] entities, RangeC components)
+		{
+			import std.algorithm : each;
+			import std.typecons : No, Yes;
+
+			return entities.each!(e => contains!(RangeC)(e, components) ? Yes.each : No.each) == Yes.each;
+		}
 	}
 
 
@@ -882,6 +1026,7 @@ unittest
 	import ecs.component : componentId;
 	auto registry = new Registry();
 	auto e0 = registry.create();
+	auto e1 = registry.create();
 
 	assertFalse(registry.contains!Position(e0));
 
@@ -890,6 +1035,10 @@ unittest
 
 	registry.add!Velocity(e0, 3, 4);
 	assertTrue(registry.contains!(Position, Velocity)(e0));
+
+	registry.add(e1, Position(1, 1), Velocity(3, 4));
+	assertTrue(registry.contains([e0, e1], Position(1, 1), Velocity(3, 4)));
+	assertFalse(registry.contains([e0, e1, registry.entityNull], Position(1, 1), Velocity(3, 4)));
 
 	registry.discard(e0);
 	assertFalse(registry.contains!(Position, Velocity)(e0));

--- a/source/ecs/registry.d
+++ b/source/ecs/registry.d
@@ -2,6 +2,7 @@ module ecs.registry;
 
 import std.exception : basicExceptionCtors;
 import ecs.entity;
+import ecs.sparseset : SparseSet;
 
 version(unittest) import aurorafw.unit.assertion;
 
@@ -33,7 +34,7 @@ public final class PoolDoesNotExistException : PoolDataException
  */
 @safe pure
 public final class BasicRegistry(T, T idBitAmount)
-	if(isEntityType!T)
+	if(isEntityType!T && __traits(compiles, SparseSet!(T, idBitAmount)))
 {
 	import std.conv : to;
 	import std.exception : enforce;
@@ -41,7 +42,6 @@ public final class BasicRegistry(T, T idBitAmount)
 	import std.traits : Fields;
 	import ecs.component : isComponent, componentId;
 	import ecs.pool : Pool;
-	import ecs.sparseset : SparseSet;
 
 	mixin genEntityBitMasks!(T, idBitAmount);
 

--- a/source/ecs/sparseset.d
+++ b/source/ecs/sparseset.d
@@ -125,11 +125,11 @@ protected:
 	 * Params: entity = valid entity which is going to be inserted
 	 */
 	@safe pure
-	void add(const inout(T) entity)
+	void add(in T entity)
 		in (!contains(entity))
 	{
-		const eid = idOf(entity);
-		const T pos = cast(T)(packedEntities.length);
+		immutable eid = idOf(entity);
+		immutable T pos = cast(T)(packedEntities.length);
 
 		packedEntities ~= entity;
 
@@ -182,7 +182,7 @@ protected:
 	 * Params: entity = valid entity to remove.
 	 */
 	@safe pure
-	void remove(const inout(T) entity)
+	void remove(in T entity)
 		in (contains(entity))
 	{
 		import std.algorithm : swap;

--- a/source/ecs/sparseset.d
+++ b/source/ecs/sparseset.d
@@ -1,0 +1,348 @@
+module ecs.sparseset;
+
+import ecs.entity : isEntityType, isValidBitIdAmount;
+
+version(unittest) import aurorafw.unit.assertion;
+
+
+/**
+ * Creates a sarse set class of an EntityType.
+ * A sparse set is formed with two arrays, a sparse and a packed arrays.
+ * The indices of the sparse array are the keys for access to the value on the
+ *     packed array. \
+ * \
+ * The value which resides in an index of the sparse array
+ *     corresponds to the index of the packed array where the data is stored.
+ * Similar to a Hash-Map but faster if you're using only numbers as keys which
+ *     is my case as entities are just a number. \
+ * \
+ * Lets imagine this case. Here we have a sparse set with all entities having
+ *     it's batch at 0, meaning the reference is equal to the id;
+ *
+ * ![](https://user-images.githubusercontent.com/1812216/89120831-8eea9d00-d4b9-11ea-86fb-a08621cfabc0.png)
+ *
+ * We have a **sparse array [2, -, 0, -, -, -, 3, 1]** and a **packed array
+ *     [2, 7, 0, 6]**. The *indices* in the **sparse array** are the ***keys***
+ *     to access the ***values*** in the **packed arrray**. The **sparse array**
+ *     *indicies* correspond to the entity's *id*. Let's say we want to get the
+ *     value for the *entity 6* (remember, all these entities in this example
+ *     have it's `batch at 0`). We get the ***id*** of this entity, which is `6`
+ *     as well, and access the **sparse array** with it. The value at index `6`
+ *     of the **sparse array** is `3` which corresponds to the **packed array
+ *     index** we must access to retrieve the **value** for this entity. At the
+ *     index `3` of the **packed array** we have the value we were looking for
+ *     `6`. \
+ * \
+ * Why is the **value** the same number as the **entity's reference**? In this
+ *     SparseSet class we store the references of the entities in the packed
+ *     array. This way we know which ones exist. \
+ * \
+ * Let's say we ask *`give me all entities contained in this SparseSet`*. We can
+ *     just return the **packed array**. Let's say we ask *`does this SparseSet
+ *     contain this entity?`* Now we just access the **sparse array** with the
+ *     entity's id, then access the **packed array** with the value found and
+ *     compare both references, if they match, then the reference exists in the
+ *     SparseSet. Something like this\:
+ *
+ * ```d
+ * packed[sparse[entity_id]] == entity;
+ * ```
+ *
+ * Obviously this SparseSet class by itself doesn't have much value in
+ *     in our case. However, when we blend this with the **Pool** class which
+ *     stores all individual components, we make wonders.
+ *
+ * Params:
+ *     T = a valid EntityType.
+ *     idBitAmount = a valid number of bits reserved for the id.
+ *
+ * See_Also: $(REF Pool, ecs.pool)
+ */
+@safe pure
+package class SparseSet(T, T idBitAmount)
+	if (isEntityType!T && isValidBitIdAmount!(T, idBitAmount))
+{
+	import ecs.registry : BasicRegistry;
+
+public:
+	/**
+	 * Check if an entity exists in the sparse set. \
+	 * An entity exists if, with all the safe checks made, the following is true\:
+	 *
+	 * ```d
+	 * packedEntities[entities[idOf(entity)]] == entity
+	 * ```
+	 *
+	 * Params: entity = reference, valid or not, to validate.
+	 *
+	 * Returns: `true` if exists, `false` otherwise
+	 *
+	 * See_Also: $(LREF canAcess)
+	 */
+	@safe pure
+	bool contains(const inout(T) entity) const inout
+	{
+		return canAccess(entity)
+			&& entities[idOf(entity)] < packedEntities.length
+			&& packedEntities[entities[idOf(entity)]] == entity;
+	}
+
+
+protected:
+	/**
+	 * Check if an entity's reference can be accessed in the sparse array. \
+	 * If the extracted id from the entity is lower than the sparse array's
+	 *     length, the entity was never inserted in the current sparse set. If
+	 *     it is lower, there is chance it might've.
+	 *
+	 * Params: entity = reference which extracted id is going to be evaluated.
+	 *
+	 * Returns: `true` if the entity's id is lower than the sparse array's
+	 *     length, `false` otherwise.
+	 *
+	 * See_Also: $(LREF contains)
+	 */
+	@safe pure
+	bool canAccess(const inout(T) entity) const inout
+	{
+		return idOf(entity) < entities.length;
+	}
+
+
+	/**
+	 * Inserts an entity in the sparse set. \
+	 * A new entity, when inserted, is pushed at the back of the packed array.
+	 *     Then it's last index, or it's length before the entity was pushed in,
+	 *     is inserted in the sparse array at the position where it's index is
+	 *     equal to the entity's id. Something like this\:
+	 *
+	 * ```d
+	 * immutable pos = packedEntities.length;
+	 * packedEntities.insertBack(entity);
+	 * entities[idOf(entity)] = pos;
+	 * ```
+	 *
+	 * Params: entity = valid entity which is going to be inserted
+	 */
+	@safe pure
+	void add(const inout(T) entity)
+		in (!contains(entity))
+	{
+		const eid = idOf(entity);
+		const T pos = cast(T)(packedEntities.length);
+
+		packedEntities ~= entity;
+
+		if (eid >= entities.length)
+		{
+			entities.length = eid + 1;
+		}
+
+		entities[eid] = pos;
+	}
+
+
+	/**
+	 * Removes an entity from the sparse set. \
+	 * When removing an entity from the sparse set we don't just simply remove
+	 *     it at it's index, that would be ineficient as it would either leave
+	 *     gaps in the packed array or it would return a new array with gaps
+	 *     making it very hard to keep in sync with the sparse array. \
+	 * \
+	 * To go around such a problem, before we remove the entity we swap it with
+	 *     the last entity of the array, update the new positions in the sparse
+	 *     array, and then remove the last element of the packed array only. How
+	 *     about the last element of the sparse array? We just don't need to
+	 *     remove it! \
+	 * \
+	 * Imagine this case, we have a **sparse array [2, -, 0, -, -, -, 3, 1]**
+	 *     and a **packed array [2, 7, 0, 6]**. We delete the entity with id 7,
+	 *     to simplify all the entities in this example have it's batch at 0, so
+	 *     it's reference is 7 as well.
+	 *
+	 * ![](https://user-images.githubusercontent.com/1812216/89120832-8f833380-d4b9-11ea-9d5f-c798c89c64c7.png)
+	 *
+	 * As you can see, we swapped the last elemen, entity 6, in the sparse array
+	 *     with the element which used to be refering to entity 7 and update the
+	 *     sparse array to point to the right place at index 6. Something like
+	 *     this\:
+	 *
+	 * ```d
+	 * immutable back = packedEntities.back;
+	 * swap(packedEntities.back, packedEntities[entities[idOf(entity)]]);
+	 * swap(entities[idOf(back)], entities[idOf(entity)]);
+	 * packedEntities.removeBack();
+	 * ```
+	 *
+	 * We don't remove the element in the sparse array because it is useless to
+	 *     do it. We know if an entity is valid if
+	 *     `packedEntities[entities[idOf(entity)]] == entity`, knowing this, it
+	 *     becomes useless to remove the element as this check will fail anyway.
+	 *
+	 * Params: entity = valid entity to remove.
+	 */
+	@safe pure
+	void remove(const inout(T) entity)
+		in (contains(entity))
+	{
+		import std.algorithm : swap;
+		import std.range : back, popBack;
+		const eid = idOf(entity);
+		const last = packedEntities.back;
+
+		swap(packedEntities.back, packedEntities[entities[eid]]);
+		swap(entities[idOf(last)], entities[eid]);
+
+		packedEntities.popBack();
+	}
+
+
+	/**
+	 * Get the id of any valid or invalid entity's reference.
+	 *
+	 * Params: entity = reference from which the id is going to be extracted.
+	 *
+	 * Returns: the entity's id
+	 */
+	@safe pure
+	inout(T) idOf(const inout(T) entity) const inout
+	{
+		return entity & BasicRegistry!(T, idBitAmount).entityMask;
+	}
+
+
+	T[] entities;
+	T[] packedEntities;
+}
+
+
+@system pure
+@("sparseset: add")
+unittest
+{
+	import std.array : array;
+	import core.exception : AssertError;
+	import std.exception : assertThrown;
+
+	SparseSet!(uint, 20) ss = new SparseSet!(uint, 20);
+	const uint e0 = 0; // simulates an entity with id(0) and batch(0)
+	const uint e6 = 6; // simulates an entity with id(6) and batch(0)
+
+	assertEquals(0, ss.entities.length);
+	assertEquals(0, ss.packedEntities.length);
+
+	ss.add(e0);
+	assertEquals(1, ss.entities.length);
+	assertEquals(1, ss.packedEntities.length);
+
+	// in this case we can use the entity directly because we know the batch is 0
+	// but internaly only the id of the entity is used as an index
+	assertSame(e0, ss.packedEntities[ss.entities[e0]]);
+
+	ss.add(e6);
+	assertEquals(e6 + 1, ss.entities.length);
+	assertEquals(2, ss.packedEntities.length);
+
+	uint[] arr;
+	arr.length = e6 - 1; // simulate the space between e0 and e6 in ss.entities
+	assertEquals(arr, ss.entities[e0 + 1 .. e6].array);
+
+	assertSame(e6, ss.packedEntities[ss.entities[e6]]);
+
+	assertThrown!AssertError(ss.add(e0));
+
+	const uint e01 = (1 << 20) | 0; // simulates an entity with id(0) and batch(1)
+	ss.add(e01); // same id but diferent batch so it adds
+
+	// now it creates a problem, the new entity was placed at the end of the packedEntities
+	// however it's id is the same as e0 and e0 was not removed!
+	// if you now remove e0 from this pool this will remove e01 from packedEntities
+	// this example will not happen in the actual world because this tested in registry
+	// and at this point e0 was already discarded and removed from this pool
+	assertEquals(e6 + 1, ss.entities.length);
+	assertEquals(3, ss.packedEntities.length);
+}
+
+
+@safe pure
+@("sparseset: contains")
+unittest
+{
+	SparseSet!(uint, 20) ss = new SparseSet!(uint, 20);
+	const uint e0 = 0; // simulates an entity with id(0) and batch(0)
+	const uint e6 = 6; // simulates an entity with id(6) and batch(0)
+	const uint e61 = (1 << 20) | 6; // simulates an entity with id(6) and batch(1)
+
+	assertFalse(ss.contains(e0));
+
+	ss.add(e6);
+
+	assertTrue(ss.contains(e6));
+	assertFalse(ss.contains(e61));
+	assertFalse(ss.contains(e0));
+}
+
+
+@safe pure
+@("sparseset: canAccess")
+unittest
+{
+	SparseSet!(uint, 20) ss = new SparseSet!(uint, 20);
+	const uint e0 = 0; // simulates an entity with id(0) and batch(0)
+	const uint e6 = 6; // simulates an entity with id(6) and batch(0)
+	const uint e61 = (1 << 20) | 6; // simulates an entity with id(6) and batch(1)
+
+	assertFalse(ss.canAccess(e6));
+
+	ss.add(e6);
+
+	assertTrue(ss.canAccess(e6));
+	assertTrue(ss.canAccess(e61));
+	assertTrue(ss.canAccess(e0));
+}
+
+
+@system pure
+@("sparseset: remove")
+unittest
+{
+	import core.exception : AssertError;
+	import std.exception : assertThrown;
+
+	SparseSet!(uint, 20) ss = new SparseSet!(uint, 20);
+	const uint e0 = 0; // simulates an entity with id(0) and batch(0)
+	const uint e6 = 6; // simulates an entity with id(6) and batch(0)
+	const uint e61 = (1 << 20) | 6; // simulates an entity with id(6) and batch(1)
+
+	ss.add(e6);
+	ss.add(e0);
+
+	assertSame(e6, ss.packedEntities[0]);
+	assertSame(e0, ss.packedEntities[1]);
+
+	assertThrown!AssertError(ss.remove(e61));
+
+	// simulate the discard of e6
+	ss.remove(e6);
+
+	assertSame(e0, ss.packedEntities[0]);
+	ss.add(e61);
+
+	assertSame(e0, ss.packedEntities[0]);
+	assertSame(e61, ss.packedEntities[1]);
+}
+
+
+@safe pure
+@("sparseset: idOf")
+unittest
+{
+	SparseSet!(uint, 20) ss = new SparseSet!(uint, 20);
+	const uint e0 = 0; // simulates an entity with id(0) and batch(0)
+	const uint e6 = 6; // simulates an entity with id(6) and batch(0)
+	const uint e61 = (1 << 20) | 6; // simulates an entity with id(6) and batch(1)
+
+	assertEquals(0, ss.idOf(e0));
+	assertEquals(6, ss.idOf(e6));
+	assertEquals(6, ss.idOf(e61));
+}


### PR DESCRIPTION
Changes:
 * Add SparseSet class
 * Add Pool class
 * Add support for pools with PoolData in Registry
 * Add component templates
 * Moved all entity's templates and exceptions into `entity.d` 
 * Made all functions `@safe` and pure
 * Moved the project into `source/ecs`

Component:
 * A component is declared by creating a struct with the UDA Component

SparseSet and Pool:
 * These new classes are package only and are managed by Registry.

PoolData:
 * Makes it possible to have an array of different Component Pools and access the Pool class

Component declaration:
```d
@Component struct ValidComponent {}
struct InvalidComponent {}
```

Adding and removing a component
```d
@Component struct Position { float x, y; }
auto registry = new Registry();
auto e0 = registry.create;
registry.add!Position(e0, 2, 3); // adds Position(2, 3)
registry.remove!Position(e0); // removes Position
```

Adding multiple components
```d
registry.add!(A, B, C, ...)(e0)
registry.add(e0, A(...), B(...), C.init, ...)
registry.add!(A, B, C, ...)([e0, e1, ...])
registry.add([e0, e1, ...], A(...), B(...), C.init, ...)
```

Removing multiple components
```d
registry.remove!(A, B, C, ...)(e0);
registry.remove!(A, B, C, ...)([e0, e1, e2, ...]);
```

Removing every component
```d
registry.removeAll(e0);
```

Get a component
```d
Position* position = registry.get!Position(e0);
auto components = registry.get!(A, B, C, ...)(e0);
```

Modify a component
```d
registry.modify!Position(e0, 4, 5);
registry.modify!Position([e0, e1, ...], 4, 5);
registry.modify(e0, A(...), B(...), ...);
registry.modify([e0, e1, ...], A(...), B(...), ...);
```

Check if an entity contains a component or multiple components or any component
```d
registry.contains!A(e0);
registry.contains(e0, A(...));
registry.contains!A([e0, e1, e2, ...]);
registry.contains([e0, e1, e2, ...], A(...));

// with all, same as using only contains
registry.containsAll!(A, B, ...)(e0); // contains A && B && ...
registry.containsAll(e0, A(...), B(...), ...); // contains A(...) && B(...) && ...
registry.containsAll!(A, B, ...)([e0, e1, e2, ...]); // all entities contain A && B && ...
registry.containsAll([e0, e1, e2, ...], A(...), B(...), ...); // all entities contain A(...) && B(...) && ...

// with any
registry.containsAny!(A, B, ...)(e0); // contains A || B || ...
registry.containsAny(e0, A(...), B(...), ...); // contains A(...) || B(...) || ...
registry.containsAny!(A, B, ...)([e0, e1, e2, ...]); // all entities contain A || B || ...
registry.containsAny([e0, e1, e2, ...], A(...), B(...), ...); // all entities contain A(...) || B(...) || ...
```